### PR TITLE
remove extra float64 slice

### DIFF
--- a/bayesian.go
+++ b/bayesian.go
@@ -273,16 +273,14 @@ func (c *Classifier) Learn(document []string, which Class) {
 // Unlike c.Probabilities(), this function is not prone to
 // floating point underflow and is relatively safe to use.
 func (c *Classifier) LogScores(document []string) (scores []float64, inx int, strict bool) {
-	n := len(c.Classes)
-	scores = make([]float64, n, n)
-	priors := c.getPriors()
+	scores = c.getPriors()
 
 	// calculate the score for each class
 	for index, class := range c.Classes {
 		data := c.datas[class]
 		// c is the sum of the logarithms
 		// as outlined in the refresher
-		score := math.Log(priors[index])
+		score := math.Log(scores[index])
 		for _, word := range document {
 			score += math.Log(data.getWordProb(word))
 		}
@@ -305,15 +303,14 @@ func (c *Classifier) LogScores(document []string) (scores []float64, inx int, st
 // instead.
 func (c *Classifier) ProbScores(doc []string) (scores []float64, inx int, strict bool) {
 	n := len(c.Classes)
-	scores = make([]float64, n, n)
-	priors := c.getPriors()
+	scores = c.getPriors()
 	sum := float64(0)
 	// calculate the score for each class
 	for index, class := range c.Classes {
 		data := c.datas[class]
 		// c is the sum of the logarithms
 		// as outlined in the refresher
-		score := priors[index]
+		score := scores[index]
 		for _, word := range doc {
 			score *= data.getWordProb(word)
 		}
@@ -341,17 +338,16 @@ func (c *Classifier) ProbScores(doc []string) (scores []float64, inx int, strict
 // has to make additional log score calculations.
 func (c *Classifier) SafeProbScores(doc []string) (scores []float64, inx int, strict bool, err error) {
 	n := len(c.Classes)
-	scores = make([]float64, n, n)
+	scores = c.getPriors()
 	logScores := make([]float64, n, n)
-	priors := c.getPriors()
 	sum := float64(0)
 	// calculate the score for each class
 	for index, class := range c.Classes {
 		data := c.datas[class]
 		// c is the sum of the logarithms
 		// as outlined in the refresher
-		score := priors[index]
-		logScore := math.Log(priors[index])
+		score := scores[index]
+		logScore := math.Log(scores[index])
 		for _, word := range doc {
 			p := data.getWordProb(word)
 			score *= p


### PR DESCRIPTION
using simple benchmark over ProbScores:

```
func BenchmarkProbScores(b *testing.B) {
	c := NewClassifier(Good, Bad)
	c.Learn([]string{"tall", "handsome", "rich"}, Good)

	for n := 0; n < b.N; n++ {
		c.ProbScores([]string{"the", "tall", "man"})
	}
}
```

old code:
BenchmarkProbScores-4    5000000               271 ns/op              32 B/op          2 allocs/op

new code:
BenchmarkProbScores-4   10000000               199 ns/op              16 B/op          1 allocs/op

of course this will be more obvious with more classes in the classifier


PS: because it makes the code less obvious, I am not sure it is worth it to be merged, I just needed the 1 less allocation.