### PR TITLE
Modernized go fmt, lint etc fixes. Simple code cleanup

### DIFF
--- a/bayesian.go
+++ b/bayesian.go
@@ -1,56 +1,3 @@
-/*
- A Naive Bayesian Classifier
- Jake Brukhman <jbrukh@gmail.com>
-
- BAYESIAN CLASSIFICATION REFRESHER: suppose you have a set
- of classes (e.g. categories) C := {C_1, ..., C_n}, and a
- document D consisting of words D := {W_1, ..., W_k}.
- We wish to ascertain the probability that the document
- belongs to some class C_j given some set of training data
- associating documents and classes.
-
- By Bayes' Theorem, we have that
-
-    P(C_j|D) = P(D|C_j)*P(C_j)/P(D).
-
- The LHS is the probability that the document belongs to class
- C_j given the document itself (by which is meant, in practice,
- the word frequencies occurring in this document), and our program
- will calculate this probability for each j and spit out the
- most likely class for this document.
-
- P(C_j) is referred to as the "prior" probability, or the
- probability that a document belongs to C_j in general, without
- seeing the document first. P(D|C_j) is the probability of seeing
- such a document, given that it belongs to C_j. Here, by assuming
- that words appear independently in documents (this being the
- "naive" assumption), we can estimate
-
-    P(D|C_j) ~= P(W_1|C_j)*...*P(W_k|C_j)
-
- where P(W_i|C_j) is the probability of seeing the given word
- in a document of the given class. Finally, P(D) can be seen as
- merely a scaling factor and is not strictly relevant to
- classificiation, unless you want to normalize the resulting
- scores and actually see probabilities. In this case, note that
-
-    P(D) = SUM_j(P(D|C_j)*P(C_j))
-
- One practical issue with performing these calculations is the
- possibility of float64 underflow when calculating P(D|C_j), as
- individual word probabilities can be arbitrarily small, and
- a document can have an arbitrarily large number of them. A
- typical method for dealing with this case is to transform the
- probability to the log domain and perform additions instead
- of multiplications:
-
-   log P(C_j|D) ~ log(P(C_j)) + SUM_i(log P(W_i|C_j))
-
- where i = 1, ..., k. Note that by doing this, we are discarding
- the scaling factor P(D) and our scores are no longer
- probabilities; however, the monotonic relationship of the
- scores is preserved by the log function.
-*/
 package bayesian
 
 import (
@@ -221,7 +168,7 @@ func NewClassifierFromFile(name string) (c *Classifier, err error) {
 	return NewClassifierFromReader(file)
 }
 
-//This actually does the deserializing of a Gob encoded classifier
+//NewClassifierFromReader deserializes a Gob encoded classifier
 func NewClassifierFromReader(r io.Reader) (c *Classifier, err error) {
 	dec := gob.NewDecoder(r)
 	w := new(serializableClassifier)
@@ -264,7 +211,7 @@ func (c *Classifier) Seen() int {
 	return int(atomic.LoadInt32(&c.seen))
 }
 
-// Returns if we are a classifier of type TfIdf
+// IsTfIdf returns true if we are a classifier of type TfIdf
 func (c *Classifier) IsTfIdf() bool {
 	return c.tfIdf
 }
@@ -324,7 +271,7 @@ func (c *Classifier) Learn(document []string, which Class) {
 	c.learned++
 }
 
-// Here we use all the TF samples for the class and convert
+// ConvertTermsFreqToTfIdf uses all the TF samples for the class and converts
 // them to TF-IDF https://en.wikipedia.org/wiki/Tf%E2%80%93idf
 // once we have finished learning all the classes and have the totals.
 func (c *Classifier) ConvertTermsFreqToTfIdf() {
@@ -333,12 +280,12 @@ func (c *Classifier) ConvertTermsFreqToTfIdf() {
 		panic("Cannot call ConvertTermsFreqToTfIdf more than once. Reset and relearn to reconvert.")
 	}
 
-	for className, _ := range c.datas {
+	for className := range c.datas {
 
-		for wIndex, _ := range c.datas[className].FreqTfs {
+		for wIndex := range c.datas[className].FreqTfs {
 			tfIdfAdder := float64(0)
 
-			for tfSampleIndex, _ := range c.datas[className].FreqTfs[wIndex] {
+			for tfSampleIndex := range c.datas[className].FreqTfs[wIndex] {
 
 				// we always want a possitive TF-IDF score.
 				tf := c.datas[className].FreqTfs[wIndex][tfSampleIndex]
@@ -502,10 +449,10 @@ func (c *Classifier) SafeProbScores(doc []string) (scores []float64, inx int, st
 func (c *Classifier) WordFrequencies(words []string) (freqMatrix [][]float64) {
 	n, l := len(c.Classes), len(words)
 	freqMatrix = make([][]float64, n)
-	for i, _ := range freqMatrix {
+	for i := range freqMatrix {
 		arr := make([]float64, l)
 		data := c.datas[c.Classes[i]]
-		for j, _ := range arr {
+		for j := range arr {
 			arr[j] = data.getWordProb(words[j])
 		}
 		freqMatrix[i] = arr
@@ -524,7 +471,7 @@ func (c *Classifier) WordsByClass(class Class) (freqMap map[string]float64) {
 	return freqMap
 }
 
-// Serialize this classifier to a file.
+// WriteToFile serializes this classifier to a file.
 func (c *Classifier) WriteToFile(name string) (err error) {
 	file, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE, 0644)
 	if err != nil {
@@ -535,12 +482,13 @@ func (c *Classifier) WriteToFile(name string) (err error) {
 
 // WriteClassesToFile writes all classes to files.
 func (c *Classifier) WriteClassesToFile(rootPath string) (err error) {
-	for name, _ := range c.datas {
+	for name := range c.datas {
 		c.WriteClassToFile(name, rootPath)
 	}
 	return
 }
 
+// WriteClassToFile writes a single class to file.
 func (c *Classifier) WriteClassToFile(name Class, rootPath string) (err error) {
 	data := c.datas[name]
 	fileName := filepath.Join(rootPath, string(name))
@@ -553,7 +501,7 @@ func (c *Classifier) WriteClassToFile(name Class, rootPath string) (err error) {
 	return
 }
 
-// Serialize this classifier to GOB and write to Writer.
+// WriteTo serializes this classifier to GOB and write to Writer.
 func (c *Classifier) WriteTo(w io.Writer) (err error) {
 	enc := gob.NewEncoder(w)
 	err = enc.Encode(&serializableClassifier{c.Classes, c.learned, int(c.seen), c.datas, c.tfIdf, c.DidConvertTfIdf})

--- a/bayesian_test.go
+++ b/bayesian_test.go
@@ -158,9 +158,9 @@ func TestSeenLearned(t *testing.T) {
 
 func TestInduceUnderflow(t *testing.T) {
 	c := NewClassifier(Good, Bad) // knows no words
-	const DOC_SIZE = 1000
-	document := make([]string, DOC_SIZE)
-	for i := 0; i < DOC_SIZE; i++ {
+	const docSize = 1000
+	document := make([]string, docSize)
+	for i := 0; i < docSize; i++ {
 		document[i] = "word"
 	}
 	// should induce overflow, because each word

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,53 @@
+/*Package bayesian is a Naive Bayesian Classifier
+  Jake Brukhman <jbrukh@gmail.com>
+
+  BAYESIAN CLASSIFICATION REFRESHER: suppose you have a set
+  of classes (e.g. categories) C := {C_1, ..., C_n}, and a
+  document D consisting of words D := {W_1, ..., W_k}.
+  We wish to ascertain the probability that the document
+  belongs to some class C_j given some set of training data
+  associating documents and classes.
+
+  By Bayes' Theorem, we have that
+
+    P(C_j|D) = P(D|C_j)*P(C_j)/P(D).
+
+  The LHS is the probability that the document belongs to class
+  C_j given the document itself (by which is meant, in practice,
+  the word frequencies occurring in this document), and our program
+  will calculate this probability for each j and spit out the
+  most likely class for this document.
+
+  P(C_j) is referred to as the "prior" probability, or the
+  probability that a document belongs to C_j in general, without
+  seeing the document first. P(D|C_j) is the probability of seeing
+  such a document, given that it belongs to C_j. Here, by assuming
+  that words appear independently in documents (this being the
+  "naive" assumption), we can estimate
+
+    P(D|C_j) ~= P(W_1|C_j)*...*P(W_k|C_j)
+
+  where P(W_i|C_j) is the probability of seeing the given word
+  in a document of the given class. Finally, P(D) can be seen as
+  merely a scaling factor and is not strictly relevant to
+  classificiation, unless you want to normalize the resulting
+  scores and actually see probabilities. In this case, note that
+
+    P(D) = SUM_j(P(D|C_j)*P(C_j))
+
+  One practical issue with performing these calculations is the
+  possibility of float64 underflow when calculating P(D|C_j), as
+  individual word probabilities can be arbitrarily small, and
+  a document can have an arbitrarily large number of them. A
+  typical method for dealing with this case is to transform the
+  probability to the log domain and perform additions instead
+  of multiplications:
+
+    log P(C_j|D) ~ log(P(C_j)) + SUM_i(log P(W_i|C_j))
+
+  where i = 1, ..., k. Note that by doing this, we are discarding
+  the scaling factor P(D) and our scores are no longer
+  probabilities; however, the monotonic relationship of the
+  scores is preserved by the log function.
+*/
+package bayesian


### PR DESCRIPTION
@jbrukh hey, I did some simple code cleanup here

- Moved the package doc to `doc.go`
- Fixed some `range` syntax
- Added some function docs
- Other minor changes recommended according to `golint`